### PR TITLE
投稿が無い場合にindex.phpが真っ白になる問題を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -109,7 +109,7 @@ function getTimeline($pdo, $start, $postsNum)
     if ($rows = $statement->fetchAll(PDO::FETCH_ASSOC)) {
         return $rows;
     } else {
-        return exit;
+        return false;
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -199,7 +199,7 @@ $posts = getTimeline($db, $start_at, $show_limit_per_page);
                 </div>
                 <!-- List group -->
                 <ul class="list-group">
-                    <?php if (empty($posts)): ?>
+                    <?php if (!$posts): ?>
                         <li class="list-group-item">
                             <div class="container-fluid">
                                 <p class="text-center">


### PR DESCRIPTION
`getTimeline()`の返り値をfalseに
